### PR TITLE
Chapter 12: Password reset

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,62 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, :valid_user, :check_expiration, only: %i(edit update)
+
+  def new; end
+
+  def create
+    @user = User.find_by email: params[:password_reset][:email].downcase
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = t "email_sent"
+      redirect_to root_url
+    else
+      flash.now[:danger] = t "email_not_found"
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if params[:user][:password].blank?
+      @user.errors.add :password, t("cant_empty")
+      render :edit
+    elsif @user.update user_params
+      log_in @user
+      @user.update_attribute :reset_digest, nil
+      flash[:success] = t "reset_successfully"
+      redirect_to @user
+    else
+      flash[:danger] = t "reset_failed"
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit :password, :password_confirmation
+  end
+
+  def get_user
+    return if @user = User.find_by(email: params[:email])
+
+    flash[:danger] = t "not_found_user"
+    redirect_to root_url
+  end
+
+  def valid_user
+    return if @user&.activated? && @user&.authenticated?(:reset, params[:id])
+
+    flash[:danger] = t "invalid_user"
+    redirect_to root_url
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = t "expired"
+    redirect_to new_password_reset_url
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :logged_in_user, except: %i(show new create)
-  before_action :load_user, only: %i(show edit destroy)
+  before_action :load_user, except: %i(index new create)
   before_action :correct_user, only: %i(edit update)
   before_action :admin_user, only: :destroy
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,5 +4,8 @@ class UserMailer < ApplicationMailer
     mail to: @user.email, subject: t("account_activation")
   end
 
-  def password_reset; end
+  def password_reset user
+    @user = user
+    mail to: @user.email, subject: t("password_reset")
+  end
 end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,16 @@
+<% provide :title, t(".title") %>
+<h1><%= t ".h1" %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for @user, url: password_reset_path(params[:id]) do |f| %>
+      <%= render "shared/error_messages" %>
+      <%= hidden_field_tag :email, @user.email %>
+      <%= f.label :password, t(".password") %>
+      <%= f.password_field :password, class: "form-control" %>
+      <%= f.label :password_confirmation, t(".confirmation") %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+      <%= f.submit t(".update_password"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,12 @@
+<% provide :title, t(".title") %>
+<h1><%= t ".h1" %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for :password_reset, url: password_resets_path do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: "form-control" %>
+      <%= f.submit t(".submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= provide :title, t(".title") %>
+<% provide :title, t(".title") %>
 <h1><%= t ".h1" %></h1>
 
 <div class="row">
@@ -7,6 +7,7 @@
       <%= f.label :email %>
       <%= f.email_field :email, class: "form-control" %>
       <%= f.label :password %>
+      <%= link_to t(".forgot_password"), new_password_reset_path %>
       <%= f.password_field :password, class: "form-control" %>
       <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t ".title" %></h1>
+<p><%= t ".click_link" %></p>
+<%= link_to t(".reset_password"), edit_password_reset_url(id: @user.reset_token,
+email: @user.email) %>
+<p><%= t ".expire" %></p>
+<p><%= t ".ignore" %></p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,4 @@
+<%= t ".click_link" %>
+<%= edit_password_reset_url id: @user.reset_token, email: @user.email %>
+<%= t ".expire" %>
+<%= t ".ignore" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,11 +2,16 @@ en:
   account_activation: Account activation
   activated: Account activated!
   base_title: Ruby on Rails Tutorial Sample App
+  cant_empty: can't be empty
   check_email: Please check your email to activate your account.
   destroy_fail: Delete failed!
   destroy_success: Deleted successfully!
+  email_not_found: Email address not found!
+  email_sent: Email sent with password reset instructions.
+  expired: Password reset has expired.
   invalid: Invalid email/password combination!
   invalid_activation: Invalid activation link!
+  invalid_user: Invalid user
   layouts:
     application:
       en: English
@@ -26,10 +31,26 @@ en:
       profile: Profile
       settings: Settings
       users: Users
+  not_found_user: User not found
+  password_reset: Password reset
+  password_resets:
+    edit:
+      confirmation: Password confirmation
+      h1: Reset password
+      password: Password
+      title: Reset password
+      update_password: Update password
+    new:
+      h1: Forgot password
+      submit: Submit
+      title: Forgot password
   please_log_in: Please log in.
   profile_updated: Profile updated
+  reset_failed: Password reset failed
+  reset_successfully: Password has been reset
   sessions:
     new:
+      forgot_password: (forgot passowrd)
       h1: Log in
       login: Log in
       new_user: New user?
@@ -91,6 +112,12 @@ en:
       hi: Hi
       title: Sample App
       welcome: "Welcome to the Sample App! Click on the link below to activate your account:"
+    password_reset:
+      click_link: "To reset your password click the link below:"
+      expire: This link will expire in two hours.
+      ignore: If you did not request your password to be reset, please ignore this email and your password will stay as it is.
+      reset_password: Reset password
+      title: Password reset
   user_not_found: User not found!
   warning_activate: Account not activated. Check your email for the activation link.
   welcome: Welcome to the Sample App!

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -2,11 +2,16 @@ vi:
   account_activation: Kích hoạt tài khoản
   activated: Kích hoạt tài khoản thành công!
   base_title: Ruby on Rails Tutorial Sample App
+  cant_empty: không được để trống
   check_email: Vui lòng kiểm tra email để kích hoạt tài khoản.
   destroy_fail: Xóa thất bại!
   destroy_success: Xóa thành công!
+  email_not_found: Email không tồn tại!
+  email_sent: Yêu cầu đã được gửi đi, vui lòng kiểm tra email để lấy lại mật khẩu.
+  expired: Liên kết đã hết hạn.
   invalid: Email/password không hợp lệ!
   invalid_activation: Liên kết kích hoạt tài khoản không hợp lệ!
+  invalid_user: Người dùng không hợp lệ
   layouts:
     application:
       en: Tiếng Anh
@@ -26,10 +31,26 @@ vi:
       profile: Hồ sơ
       settings: Cài đặt
       users: Người dùng
+  not_found_user: Người dùng không tồn tại
+  password_reset: Yêu cầu lấy lại mật khẩu
+  password_resets:
+    edit:
+      confirmation: Xác nhận mật khẩu
+      h1: Lấy lại mật khẩu
+      password: Mật khẩu
+      title: Lấy lại mật khẩu
+      update_password: Cập nhật mật khẩu
+    new:
+      h1: Quên mật khẩu
+      submit: Lấy lại mật khẩu
+      title: Quên mật khẩu
   please_log_in: Please log in.
   profile_updated: Cập nhật thành công
+  reset_failed: Cập nhật mật khẩu thất bại
+  reset_successfully: Cập nhật mật khẩu mới thành công
   sessions:
     new:
+      forgot_password: (quên mật khẩu)
       h1: Đăng nhập
       login: Đăng nhập
       new_user: Người dùng mới?
@@ -91,6 +112,12 @@ vi:
       hi: Chào
       title: Sample App
       welcome: "Chào mừng bạn đến với Sample App! Click vào đường link phía dưới để kích hoạt tài khoản:"
+    password_reset:
+      click_link: "Để lấy lại mật khẩu, nhấn vào liên kết phía dưới:"
+      expire: Liên kế này sẽ hết hạn sau 2 giờ đồng hồ.
+      ignore: Nếu bạn không yêu cầu lấy lại mật khẩu, vui lòng bỏ qua email này và mật khẩu của bạn vẫn được giữ nguyên.
+      reset_password: Lấy lại mật khẩu
+      title: Lấy lại mật khẩu
   user_not_found: Không tìm thấy người dùng!
   warning_activate: Tài khoản chưa được kích hoạt. Vui lòng kiểm tra email để lấy liên kết kích hoạt.
   welcome: Chào mừng bạn đến với Sample App!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,6 @@ Rails.application.routes.draw do
 
     resources :users
     resources :account_activations, only: :edit
+    resources :password_resets, except: %i(index show destroy)
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,5 +23,6 @@ user:
     length: 50
   password:
     length: 6
+    expire_time: 2
 session:
   remember: "1"

--- a/db/migrate/20200904015800_add_reset_to_users.rb
+++ b/db/migrate/20200904015800_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_022058) do
+ActiveRecord::Schema.define(version: 2020_09_04_015800) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2020_09_01_022058) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
"Password reset" cho phép người dùng đặt lại mật khẩu thông qua một url được gửi đến email người dùng. Cơ chế hoạt động tương tự như "Account activation"
- Người dùng gửi yêu cầu lấy lại mật khẩu kèm email. Nếu email tồn tại trong database, reset_token và reset_digest được tạo ra.
- reset_digest được lưu vào trong database còn reset_token được gửi đến email người dùng thông qua một url.
- Khi người dùng nhấn vào url chứa reset_token, hệ thống xác thực thông tin người dùng thông qua email đính kèm trong url và so sánh reset_token với reset_digest trong database.
- Nếu thành công sẽ render một form cho phép người dùng cập nhật mật khẩu mới.